### PR TITLE
Troll Accounts die immer nichts besonderes in den Chat schreiben und Streamer eher nerven!

### DIFF
--- a/hate_troll_list_h_m.txt
+++ b/hate_troll_list_h_m.txt
@@ -2833,6 +2833,7 @@ lauterbach_official
 lavadrag0n
 lawandorder________
 laxnacken12
+lazer958_
 lazerlilly_
 lazerlori
 lazyseafowl1650
@@ -5286,6 +5287,7 @@ mr_kakapopoloch1
 mr_knalltuete
 mr_mantilla
 mr_maxii1
+mr_olddeath
 mr_patrick
 mranalos123
 mrburtburt
@@ -5293,6 +5295,7 @@ mrcl_98
 mrclnsmt
 mrcynaptic
 mrdrassi
+mreichli
 mrexorius
 mrfliesentischbesitzer
 mrfloppapotamus


### PR DESCRIPTION
lazer958_
mreichli
mr_olddeath

Wurden hinzugefügt, Troll Accounts die viel unnützes in den Chat schreiben und hauptsächlich nur Troll Antworten geben und den Streamer meist nur nerven.  Sind öfters auffällig geworden bei mehreren Streamern.